### PR TITLE
feat:HACCP 페이지 UI 디자인 및 레이아웃 변경

### DIFF
--- a/src/components/Common/Search/Search.module.scss
+++ b/src/components/Common/Search/Search.module.scss
@@ -1,38 +1,57 @@
 /* 검색창 */
 .search_container {
-    left: 50%;
-    width: 90%;
-    max-width: 768px;
-    margin: 8rem auto 3rem auto;
-    border-radius: 5px;
-    border: 1px solid rgb(136, 156, 255);
-    display: flex;
-    justify-content: space-between;
-  }
+  width: 100%;
+  margin: 8rem 0 1rem 0;
+  padding: 30px 15px 25px;
+  border-radius: 5px;
+  border: 1px solid rgb(195, 193, 193);
+  display: flex;
+  justify-content: space-between;
+  position: relative;
   
-  .search_input {
-    border: none;
-    background: transparent;
-    padding: 10px 15px;
-    min-width: 150px;
-    width: 100%;
-  }
-  
-  .search_input:focus {
-    outline: none;
-  }
-  
-  /* 검색 버튼 */
-  .search_btn {
-    right: 0;
-    border-radius: 3px;
-    min-width: 65px;
-    color: white;
-    padding: 11px 15px;
-    border: none;
-    background-color: rgb(98, 98, 238);
-  }
-  
-  .search_btn:hover {
-    background-color: rgb(120, 120, 250);
-  }
+}
+
+// 검색 폼 타이틀
+.search_form_title {
+  position: absolute;
+  background-color: #1a4e85;
+  color: white;
+  border-radius: 5px;
+  padding: 5px;
+  margin: 0 0 8px 0;
+  display: inline-block;
+  left: 0.5em;
+  top: -1em;
+}
+
+// 검색창
+.search_input {
+  border: none;
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+  background: rgb(224, 224, 224);
+  padding: 10px 20px;
+  min-width: 150px;
+  width: 100%;
+}
+
+.search_input:focus {
+  outline: none;
+  background-color: rgb(233, 234, 236);
+}
+
+/* 검색 버튼 */
+.search_btn {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  right: 0;
+  min-width: 65px;
+  color: white;
+  padding: 11px 15px;
+  border: none;
+  background-color: rgb(68, 124, 184);
+}
+
+.search_btn:hover {
+  background-color: rgb(54, 104, 158);
+}

--- a/src/components/Common/Search/SearchForm.tsx
+++ b/src/components/Common/Search/SearchForm.tsx
@@ -2,7 +2,6 @@ import styles from './Search.module.scss'
 
 import {type FormEventHandler, type MouseEventHandler } from 'react'
 import SearchButton from "./SearchButton";
-// import ReactSpinner from "../../UI/ReactSpinner";
 import SearchInput from "./SearchInput";
 
 interface PropsType {
@@ -26,6 +25,7 @@ interface PropsType {
 export default function SearchForm({ action, onSearch, inputOptions, buttonOptions }: PropsType) {
     return (
         <form className={styles.search_container} onSubmit={action}>
+            <h2 className={styles.search_form_title}>검색</h2>
             <SearchInput
                 inputOptions={inputOptions}
             />

--- a/src/pages/Haccp/Haccp.module.scss
+++ b/src/pages/Haccp/Haccp.module.scss
@@ -2,6 +2,9 @@
 
 .Haccp {
   min-height: 150vh;
+  max-width: 1240px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .haccp_inner_container {
@@ -26,7 +29,7 @@
   margin: 0 0 3rem 0 !important;
   padding-top: 5rem;
   color: white;
-  background-position:right;
+  background-position: right;
   background: url('/assets/haccpback.png');
 
   p {
@@ -38,35 +41,56 @@
 
 /* 잠깐 알고가기! */
 .message {
-  padding: 1.5rem 10px;
   line-height: 1.7;
+  padding: 1.5em 0;
   font-size: calc(15px);
-  max-width: 600px;
   margin: 0rem auto;
+  position: relative;
 
-  span {
-    background-color: rgb(82, 82, 255);
-    box-shadow:
-      inset 2px 2px 2px rgb(155, 155, 255),
-      inset -2px -2px 2px rgb(34, 34, 101);
+  h2 {
+    position: absolute;
+    background-color: #1a4e85;
+    color: white;
+    border-radius: 5px;
+    padding: 5px;
     margin: 0 0 8px 0;
     display: inline-block;
-    color: white;
-    border-radius: 10px;
-    padding: 5px;
+    left: 0.5em;
+
+  }
+  p {
+    border-radius: 5px;
+    border: 1px solid rgb(195, 193, 193);
+    padding: 1em;
   }
 }
 
 /* 상품 목록 */
 .content_container {
+  border-radius: 5px;
+  padding-top: 7em;
+  border: 1px solid rgb(195, 193, 193);
   width: 100%;
   position: relative;
-  margin: 3em auto 7em;
   justify-content: center;
   gap: 15px;
   top: 1rem;
   display: grid;
-  grid-template-columns: 330px 330px 330px 330px;
+  grid-template-columns: 295px 295px 295px 295px;
+
+  // 상품 목록 타이틀
+  .haccp_product_list_title {
+    position: absolute;
+    background-color: #1a4e85;
+    color: white;
+    border-radius: 5px;
+    padding: 5px;
+    margin: 0 0 8px 0;
+    display: inline-block;
+    left: 0.5em;
+    top: -1em;
+
+  }
 
   // 상품 카드
   .haccp_card_container {
@@ -85,7 +109,9 @@
       position: relative;
       transform: translateY(-50px);
       width: 85%;
-      box-shadow: 0 0 0 15px rgba(255, 255, 255, 1), 0 0 30px 1px black;
+      box-shadow:
+        0 0 0 15px rgba(255, 255, 255, 1),
+        0 0 30px 1px black;
       max-height: 260px;
       height: 300px;
     }
@@ -101,7 +127,7 @@
       padding: 13px;
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
-      box-shadow: 1px 4px 1px 0 rgba(0,0,0,0.2);
+      box-shadow: 1px 4px 1px 0 rgba(0, 0, 0, 0.2);
       vertical-align: middle;
       padding-top: 10px;
       text-align: start;

--- a/src/pages/Haccp/HaccpCategoryGrid.module.scss
+++ b/src/pages/Haccp/HaccpCategoryGrid.module.scss
@@ -1,28 +1,32 @@
 .haccp_category_container {
-  max-width: 768px;
+  max-width: 1240px;
   margin: 0 auto;
+  position: relative;
 
   .haccp_category_title {
     margin: 0 0 2% 0;
-    font-size: 1.05em;
     display: inline-block;
-    font-weight: 600;
+    background-color: #1a4e85;
+    color: white;
+    border-radius: 5px;
+    position: absolute;
+    top: -1em;
+    left: 0.5em;
     padding: 5px;
-    border-bottom: 2px solid gray;
-
   }
 }
 
 .haccp_category_grid {
   --default-interval-left: 100px;
   --default-interval-top: 100px;
-
+  border-radius: 5px;
+  border: 1px solid rgb(195, 193, 193);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(105px, 105px));
+  grid-template-columns: repeat(auto-fit, minmax(112.72px, 112.72px));
   justify-content: center;
-  margin: 0 auto;
+  margin: 1em auto;
+  padding: 2.3em 0 1em;
   gap: 5px;
-
 
   .haccp_category_grid_cell {
     transition: 0.5s;
@@ -40,7 +44,7 @@
       overflow: hidden;
       position: relative;
       border: 1px solid #ddd;
-      
+
       border-radius: 5px;
       .haccp_category_grid_cell_img {
         width: 894px;
@@ -54,11 +58,11 @@
       }
     }
   }
-  .haccp_category_grid_cell:hover{
-    box-shadow: 0 0 30px 0 rgba(0,0,0,0.3);
+  .haccp_category_grid_cell:hover {
+    box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3);
   }
 
-/** 이미지 스프라이트 처리 */
+  /** 이미지 스프라이트 처리 */
   //   양념육
   .haccp_category_grid_cell:nth-of-type(2) {
     .haccp_category_grid_cell_img {
@@ -250,7 +254,6 @@
   }
 }
 
-
 // 카테고리 활성화 체크
 .haccp_category_grid_cell.active::before {
   content: 'Pick';
@@ -260,7 +263,7 @@
   font-size: 0.85em;
   border-radius: 10px;
   background-color: gold;
-  color:black;
+  color: black;
   top: -8px;
   right: -10px;
 }

--- a/src/pages/Haccp/HaccpPage.tsx
+++ b/src/pages/Haccp/HaccpPage.tsx
@@ -43,7 +43,7 @@ function HaccpPage() {
     },
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
-      return Number(lastPage.body.pageNo) + 1 ?? undefined
+      return Number(lastPage.body.pageNo) + 1 || undefined
     },
   })
 
@@ -58,20 +58,27 @@ function HaccpPage() {
     setPrdkind(name)
   }
 
-  function searchAction(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const input = e.currentTarget.firstChild
+  function getSearchValue(input: HTMLInputElement) {
+
     if (!(input instanceof HTMLInputElement)) return
     const searchProduct = input.value
-    setProductName(searchProduct)
+
+    return searchProduct
+
   }
 
-  function onSearch(e:MouseEvent<HTMLButtonElement>){
-    const input = e.currentTarget.previousElementSibling
-    if (!(input instanceof HTMLInputElement)) return
-    const searchProduct = input.value
-    setProductName(searchProduct)
+  function searchAction(e: SyntheticEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const input = e.currentTarget.childNodes[1] as HTMLInputElement
+    const productName = getSearchValue(input)
+    setProductName(productName || '')
 
+  }
+
+  function onSearch(e: MouseEvent<HTMLButtonElement>) {
+    const input = e.currentTarget.previousElementSibling as HTMLInputElement
+    const productName = getSearchValue(input)
+    setProductName(productName || '')
   }
 
 
@@ -80,13 +87,13 @@ function HaccpPage() {
   }, []);
 
   useEffect(() => {
-    if (isEnd && hasNextPage && totalCount>99) {
+    if (isEnd && hasNextPage && totalCount > 99) {
       setPageNo(old => old + 1)
       fetchNextPage()
     }
   }, [isEnd])
 
-
+  
   return (
     <section className={styles.Haccp} ref={haccpContainerRef}>
       <h2 className={styles.haccp_page_title}>
@@ -103,7 +110,7 @@ function HaccpPage() {
         {/* 잠깐 알고가기 */}
         <HaccpMessage />
         {/* 품목 유형 카테고리 */}
-        <HaccpCategoryGrid categoryName={prdkind} onSetPrdkind={onSetPrdkind}/>
+        <HaccpCategoryGrid categoryName={prdkind} onSetPrdkind={onSetPrdkind} />
         <br />
       </div>
 

--- a/src/pages/Haccp/components/HaccpMessage.tsx
+++ b/src/pages/Haccp/components/HaccpMessage.tsx
@@ -3,12 +3,13 @@ export default function HaccpMessage() {
 
 
     return (
-        <p className={styles.message}>
+        <div className={styles.message}>
             {' '}
-            <span>잠깐 알고가기</span> <br />
-            해썹(HACCP) 제도는 식품, 축산물, 사료 등을 만드는 과정에서 생물학적, 화학적, 물리적
-            위해요인들이 발생할 수 있는 상황을 과학적으로 분석하고 사전에 위해요인의 발생여건들을
-            차단하여 소비자에게 안전하고 깨끗한 제품을 공급하기 위한 시스템적인 규정을 말합니다.
-        </p>
+            <h2>잠깐 알고가기</h2> <br />
+            <p className={styles.message_content}>
+                해썹(HACCP) 제도는 식품, 축산물, 사료 등을 만드는 과정에서 생물학적, 화학적, 물리적
+                위해요인들이 발생할 수 있는 상황을 과학적으로 분석하고 사전에 위해요인의 발생여건들을
+                차단하여 소비자에게 안전하고 깨끗한 제품을 공급하기 위한 시스템적인 규정을 말합니다.</p>
+        </div>
     )
 }

--- a/src/pages/Haccp/components/HaccpProductCard.tsx
+++ b/src/pages/Haccp/components/HaccpProductCard.tsx
@@ -1,6 +1,6 @@
 import styles from '../Haccp.module.scss'
 
-import { HaccpProductItemType } from "../../../types/Haccp.types"
+import { HaccpProductItemType } from "@/types/Haccp.types"
 
 interface PropsType {
   product:HaccpProductItemType
@@ -14,15 +14,15 @@ export default function HaccpProductCard({product}:PropsType) {
     >
       <div id="item_box">
         <img className={styles.haccp_card_img} src={`${product.item.imgurl1}`} alt="상품이미지"></img>
-        <p className={styles.haccp_card_content}>
+        <div className={styles.haccp_card_content}>
           <h3 className={styles.product_name}> {product.item.prdlstNm || '알수없음'}</h3>
-          <div className={styles.product_sort}><span>분류</span> {product.item.prdkind || '알수없음'}</div>
-          <div><span>열량</span> {product.item.capacity || '알수없음'}</div>
-          <div><span>성분</span> {product.item.rawmtrl || '알수없음'}</div>
-          <div><span>알러지</span> {product.item.allergy || '알수없음'}</div>
-          <div><span>제조사</span> {product.item.manufacture || '알수없음'}</div>
-          <div><span>판매자</span> {product.item.seller || '알수없음'}</div>
-        </p>
+          <p className={styles.product_sort}><span>분류</span> {product.item.prdkind || '알수없음'}</p>
+          <p><span>열량</span> {product.item.capacity || '알수없음'}</p>
+          <p><span>성분</span> {product.item.rawmtrl || '알수없음'}</p>
+          <p><span>알러지</span> {product.item.allergy || '알수없음'}</p>
+          <p><span>제조사</span> {product.item.manufacture || '알수없음'}</p>
+          <p><span>판매자</span> {product.item.seller || '알수없음'}</p>
+        </div>
       </div>
     </figure>
   )

--- a/src/pages/Haccp/components/HaccpResult.tsx
+++ b/src/pages/Haccp/components/HaccpResult.tsx
@@ -25,6 +25,7 @@ function HccpResult({ products, totalCount}: PropsType) {
   return (
     <>
     <section className={styles.content_container} ref={containerRef}>
+      <h2 className={styles.haccp_product_list_title}>상품목록</h2>
       <HaccpGuide totalProductCount={totalCount} currentProductCount={currentProductCount} />
       <HaccpProductList products={products} />
       

--- a/src/pages/Haccp/components/HaccpSearchForm.tsx
+++ b/src/pages/Haccp/components/HaccpSearchForm.tsx
@@ -2,7 +2,7 @@ import { type FormEventHandler, type MouseEventHandler, useEffect, useRef } from
 
 import useFoucs from '../../../hooks/useFocus';
 
-import SearchForm from '../../../components/Common/Search/SearchForm';
+import SearchForm from '@components/Common/Search/SearchForm';
 
 interface Type {
   productName: string;


### PR DESCRIPTION
## 개요
#### 기존의 밋밋하고 비어 보이는 디자인을
![image](https://github.com/youngwan2/food-picker/assets/107159871/06148c2f-aa54-4d4a-ba50-9cadcb90223c)

#### 통일성 있고, 규칙성 있는 모던한 디자인으로 수정함
![image](https://github.com/youngwan2/food-picker/assets/107159871/0c975236-037c-4f33-9b6d-3fa1c7d781ba)
![image](https://github.com/youngwan2/food-picker/assets/107159871/a3ab1895-6235-4c54-8b0a-9952b114f264)


#### 페이지를 축소해서 보면 다음과 같이 1240px 를 넘지 않도록 하였고, 여백을 통일함
![image](https://github.com/youngwan2/food-picker/assets/107159871/74125cdc-a3c1-413c-9e29-ab5966f7f839)


