### PR TITLE
Haccp 상품 카드 호버 시 아무런 호버 효과가 나타나지 않는 문제 개선

### DIFF
--- a/src/pages/Haccp/Haccp.module.scss
+++ b/src/pages/Haccp/Haccp.module.scss
@@ -157,6 +157,14 @@
     }
   }
   // 카드 호버
+  .haccp_card_container:hover{
+    .haccp_card_img {
+      transform: translateY(-70px)  perspective(600px) ;
+      opacity: 085;
+      cursor: pointer;
+    }
+
+  }
   .haccp_card_container:focus {
     z-index: 100;
     transform: scale(1.05);

--- a/src/pages/Haccp/components/HaccpProductCard.tsx
+++ b/src/pages/Haccp/components/HaccpProductCard.tsx
@@ -12,7 +12,7 @@ export default function HaccpProductCard({product}:PropsType) {
       className={styles.haccp_card_container}
       key={product.item.prdlstReportNo}
     >
-      <div id="item_box">
+      <div id="item_box" title={product.item.prdlstNm}>
         <img className={styles.haccp_card_img} src={`${product.item.imgurl1}`} alt="상품이미지"></img>
         <div className={styles.haccp_card_content}>
           <h3 className={styles.product_name}> {product.item.prdlstNm || '알수없음'}</h3>


### PR DESCRIPTION
## 개요
- Haccp 내 조회된 상품 카드 호버 시 아무런 호버 효과가 나타나지 않음으로 이에 대한 효과를 추가함으로써 개선. 사실 상 제거된 기능을 다시 추가한 것과 같음.
- 참고로 해당 상품 카드 위에 호버하는 경우  해당 요소의 title 속성에 상품 이름이 표시되도록 추가함

![image](https://github.com/youngwan2/food-picker/assets/107159871/33e3bc9b-038f-4523-9ab1-dd88218db4f7)
