### PR TITLE
레이아웃 깨짐 문제 외  페이지네이션 깨짐 문제 개선

### DIFF
--- a/src/components/Common/Label.tsx
+++ b/src/components/Common/Label.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react'
+import {  ReactNode } from 'react'
 
 interface PropsType {
     htmlFor: string

--- a/src/hooks/useDefaultQuery.tsx
+++ b/src/hooks/useDefaultQuery.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { ApiType, getDefaultFetcher } from '../api/get.api';
 import { toast } from 'react-toastify';
 
@@ -9,10 +9,13 @@ import { toast } from 'react-toastify';
  * @returns
  */
 export default function useDefaultQuery(key: any[], url: string) {
-  const { data, isPending, isError, error, isFetching } = useQuery({
+
+ 
+  const { data, isPending, isError, error, isFetching,isPlaceholderData} = useQuery({
     queryKey: key,
     queryFn: () => getDefaultFetcher(url,ApiType.INTERNAL),
+    placeholderData: keepPreviousData,
   });
   if(isError) toast.error('데이터 조회에 실패하였습니다.')
-  return { data, isPending, isError, error, isFetching };
+  return { data, isPending, isError, error, isFetching, isPlaceholderData};
 }

--- a/src/pages/Nutrition/NutritionPage.tsx
+++ b/src/pages/Nutrition/NutritionPage.tsx
@@ -17,6 +17,7 @@ import { NutritionPageNumber, nutritionKcalFilter } from '../../atom/NutritionsA
 import { debounce } from '@/utils/helpers';
 
 
+
 interface KeywordType {
   companyName: string[]
   foodType: string[]
@@ -30,18 +31,20 @@ export default function NutritionPage() {
   const [keywords, setKeywords] = useState<KeywordType>({ companyName: [], foodType: [] })
   const [kcal] = useRecoilState(nutritionKcalFilter)
 
+
+
   useEffect(() => {
     document.title = '식품영양정보조회 | FoodPicker';
   }, []);
 
   const url = `/nutritions?name=${productName}&company_name=${keywords.companyName}&food_type=${keywords.foodType}&min_kcal=${kcal.min}&max_kcal=${kcal.max}&page=${page}`;
   const queryKey = ['nutrition', productName, keywords, kcal, page];
-  const { data = [], error, isError, isFetching, isPending } = useDefaultQuery(queryKey, url);
+  const { data = [], error, isError, isFetching} = useDefaultQuery(queryKey, url);
   const { items: products, totalCount = 0 } = data
   const hasProducts = Array.isArray(products) && products.length > 0;
   const totalPage = Math.ceil(totalCount / MIN_VIEW_COUNT) || 1;
 
-  
+
 
   /** 검색어 반환 */
   function getSearchValue(input: HTMLInputElement) {

--- a/src/pages/TraditionalFood/TraditionalFood.module.scss
+++ b/src/pages/TraditionalFood/TraditionalFood.module.scss
@@ -62,7 +62,7 @@
     padding: 3.5em 0;
     border-radius: 5px;
     position: relative;
-    min-height: 10vh;
+    min-height: 60vh;
     height: 100%;
 
     .traditional_food_list_title {


### PR DESCRIPTION
## 개요
- 전통음식 페이지의 목록 조회 시 레이아웃이 깨지는 문제를 해당 목록 컨테이너의 min-height 값 조정을 통해서 개선
- 추가로 음식영양정보 조회 페이지에서 사용 중인 페이지네이션의 경우 다음 페이지에 대한 추가 요청 시 페이지네이션 자체가 깨지는 문제가 보였음. 해당 문제의 원인은 Pagination 컴포넌트로 전달하는 데이터가 새로운 데이터 페칭 시 잠시 누락되기 때문. 따라서  Tanstack/query-react 에서 제공하는   placeholderData 및 keepPreviousData 을 활용하여 추가 데이터 로드 이전에 기존 데이터를 placeholder 형식으로 사용 후 새 데이터가 도착하는 순간 교체되도록 함으로써 개선

## 연관 이슈
[전통식품 데이터 조회 시 리스트 레이아웃 시프트 현상 #41](https://github.com/youngwan2/food-picker/issues/41)

## 결과 이미지
- 데스크톱 사이즈에서 조회된 목록이 차지하는 뷰포트 만큼 최소 높이를 지정함으로써 레이아웃 시프트 문제를 개선
- 비고: 모바일 환경에서는 어떻게 동작하는 지 테스트 할 필요 있음
### 전통음식 페이지 추가 로드 요청 전
![image](https://github.com/youngwan2/food-picker/assets/107159871/856fb09a-30fd-46ba-b13a-5bdf66f42b1c)

### 전통음식 페이지 추가 로드 요청 중
![image](https://github.com/youngwan2/food-picker/assets/107159871/6f47d7aa-71eb-499f-8ae7-71a94e7dd967)
