### PR TITLE
스토로지 단위 테스트 추가

### DIFF
--- a/src/utils/__test__/storage.test.ts
+++ b/src/utils/__test__/storage.test.ts
@@ -1,0 +1,80 @@
+import {describe, beforeEach, it, expect, vi} from 'vitest'
+import { StorageType, getLocalStorageItem, getSessionStorageItem, setStorage } from '../storage'; // 실제 경로로 수정하세요
+
+describe('getLocalStorageItem', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('key 에 해당하는 아이템을 로컬 스토로지로 부터 가져온다.', () => {
+        const key = 'testKey';
+        const value = JSON.stringify({ data: 'testData' });
+        localStorage.setItem(key, value);
+
+        const retrievedValue = getLocalStorageItem(key);
+        expect(retrievedValue).toBe(value);
+    });
+
+    it('key 에 해당하는 아이템이 존재하지 않으면 null 을 반환한다.', () => {
+        const key = 'nonExistentKey';
+        const retrievedValue = getLocalStorageItem(key);
+        expect(retrievedValue).toBeNull();
+    });
+
+    it('null 을 반환하는 경우 에러가 throw 된다.', () => {
+        const key = 'testKey';
+        vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+            throw new Error('Simulated error');
+        });
+
+        const retrievedValue = getLocalStorageItem(key);
+        expect(retrievedValue).toBeNull();
+    });
+});
+
+describe('getSessionStorageItem', () => {
+    beforeEach(() => {
+        sessionStorage.clear();
+    });
+
+    it('key에 해당하는 아이템을 세션 스토로지에 부터 가져온다.', () => {
+        const key = 'testKey';
+        const value = JSON.stringify({ data: 'testData' });
+        sessionStorage.setItem(key, value);
+
+        const retrievedValue = getSessionStorageItem(key);
+        expect(retrievedValue).toBe(value);
+    });
+
+    it('key에 해당하는 아이템이 세션 스토로지에 없으면 null 을 반환한다.', () => {
+        const key = 'nonExistentKey';
+        const retrievedValue = getSessionStorageItem(key);
+        expect(retrievedValue).toBeNull();
+    });
+
+    it('null을 반환하는 경우 에러가 throw 된다.', () => {
+        const key = 'testKey';
+        vi.spyOn(window.sessionStorage, 'getItem').mockImplementation(() => {
+            throw new Error('Simulated error');
+        });
+
+        const retrievedValue = getSessionStorageItem(key);
+        expect(retrievedValue).toBeNull();
+    });
+});
+
+
+describe('setStorage',()=>{
+ 
+    beforeEach(()=>{
+        localStorage.clear();
+        sessionStorage.clear();
+    })
+
+    it('유효한 스토어 타입이 아니라면 에러를 반환한다.',()=>{
+        const key = 'testKey';
+        const value = {data: 'textData'}
+
+        expect(()=>setStorage({type:'INVAILD_TYPE' as StorageType,key,value})).toThrow('유효한 스토로지 타입이 아님')
+    })
+})

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -9,26 +9,44 @@ interface SetStorageType {
     key: string
     value: any
 }
-export function setStoreage({ type, key, value }: SetStorageType) {
 
-    if (type === StorageType.LOCAL) {
-        window.localStorage.setItem(key, JSON.stringify(value))
+/** 브라우저 캐싱 */
+export function setStorage({ type, key, value }: SetStorageType) {
+    try {
+        const serializedValue = JSON.stringify(value);
+
+        if (type === StorageType.LOCAL) {
+            window.localStorage.setItem(key, serializedValue);
+        } else if (type === StorageType.SESSION) {
+            window.sessionStorage.setItem(key, serializedValue);
+        } else {
+            throw new Error('유효한 스토로지 타입이 아님');
+        }
+    } catch (error) {
+        console.error('set Storage 실패:', error);
+        throw error;
     }
+}
 
-    if (type === StorageType.SESSION) {
-        window.sessionStorage.setItem(key, JSON.stringify(value))
+
+export function getLocalStorageItem(key: string): string | null {
+    try {
+        return window.localStorage.getItem(key);
+    } catch (error) {
+        console.error('get Storage 실패:', error);
+        return null;
     }
 }
 
-
-function getLocalStorageItem(key: string) {
-    return window.localStorage.getItem(key)
+export function getSessionStorageItem(key: string): string | null {
+    try {
+        return window.sessionStorage.getItem(key);
+    } catch (error) {
+        console.error('get Storage 실패:', error);
+        return null;
+    }
 }
 
-function getSessionStorageItem(key: string) {
-    return window.sessionStorage.getItem(key)
-
-}
 
 /**
  * 스토로지에 저장된 데이터를 읽어온다.


### PR DESCRIPTION
## 개요
- 브라우저 스토로지를 레시피 캐싱 용도로 재사용하고 있는데, 해당 로직에서 매번 키를 읽어올 수 없음 이라는 에러가 발생함. 따라서 해당 로직에 대한 예외처리 로직을 추가하고, 향후 에러에 대해 대처할 수 있도록 단위 테스트를 추가함.